### PR TITLE
Add domain suggestion feature

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -128,6 +128,28 @@ By default, Talia sleeps 2 seconds (`--sleep=2s`) between each domain WHOIS quer
 
 As shown above, `--sleep` changes how long Talia waits between domain checks.
 
+### Generating Domain Suggestions
+
+Use the `--suggest` flag to create a JSON file containing domain ideas without
+running any WHOIS checks. The result is written in the same grouped format with
+an `"unverified"` array so you can immediately feed it back into Talia for
+checking.
+
+    OPENAI_API_KEY=... ./talia --suggest=5 --prompt="three word tech names" suggestions.json
+
+The file `suggestions.json` will contain:
+
+```json
+{
+  "unverified": [
+    { "domain": "..." }
+  ]
+}
+```
+
+You can then run Talia with `--whois` against this file to verify the suggested
+domains.
+
 ### Verbose Mode
 
 By default, Talia only writes the WHOIS response to the `"log"` field if there's an error. If you set `--verbose`, Talia stores the full WHOIS response for every domain:

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,6 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.19.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/openai/openai-go v1.1.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -170,10 +169,6 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
 	github.com/tetafro/godot v1.5.1 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,6 @@ github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0
 github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
 github.com/onsi/gomega v1.36.3 h1:hID7cr8t3Wp26+cYnfcjR6HpJ00fdogN6dqZ1t6IylU=
 github.com/onsi/gomega v1.36.3/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
-github.com/openai/openai-go v1.1.0 h1:daSn+y+3QJUmLV1xfh7B8QtgJYRw1hg3yWxKtQDfROE=
-github.com/openai/openai-go v1.1.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
@@ -571,16 +569,6 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.5.1 h1:PZnjCol4+FqaEzvZg5+O8IY2P3hfY9JzRBNPv1pEDS4=
 github.com/tetafro/godot v1.5.1/go.mod h1:cCdPtEndkmqqrhiCfkmxDodMQJ/f3L1BCNskCUZdTwk=
-github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
-github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
-github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
-github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 h1:9LPGD+jzxMlnk5r6+hJnar67cgpDIz/iyD+rfl5r2Vk=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/timonwong/loggercheck v0.11.0 h1:jdaMpYBl+Uq9mWPXv1r8jc5fC3gyXx4/WGwTnnNKn4M=

--- a/suggestions.go
+++ b/suggestions.go
@@ -1,0 +1,128 @@
+package talia
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// suggestionSchema defines the JSON structure returned by OpenAI when
+// generating domain suggestions. It matches the ExtendedGroupedData
+// format used by Talia so the suggestions can be fed back into the
+// existing checking workflow.
+type suggestionSchema struct {
+	Unverified []DomainRecord `json:"unverified"`
+}
+
+// Default HTTP client and base URL for the OpenAI API.
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+var (
+	suggestionHTTPClient httpDoer = http.DefaultClient
+	openAIBase                    = "https://api.openai.com/v1"
+)
+
+// GenerateDomainSuggestions contacts the OpenAI API using structured output
+// to get domain suggestions. The returned list can be used as the
+// "unverified" field in an ExtendedGroupedData file.
+func GenerateDomainSuggestions(apiKey, prompt string, count int) ([]DomainRecord, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+
+	// Build minimal JSON schema for structured output.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"unverified": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"domain": map[string]any{"type": "string"}},
+					"required":   []string{"domain"},
+				},
+			},
+		},
+		"required":             []string{"unverified"},
+		"additionalProperties": false,
+	}
+	schemaBytes, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+
+	body := map[string]any{
+		"model": "gpt-4o", // default model name
+		"messages": []map[string]string{
+			{"role": "system", "content": "You generate domain name ideas."},
+			{"role": "user", "content": fmt.Sprintf("%s Return %d unique domain suggestions in the 'unverified' array.", prompt, count)},
+		},
+		"response_format": map[string]any{
+			"type": "json_schema",
+			"json_schema": map[string]any{
+				"name":   "suggestionSchema",
+				"schema": string(schemaBytes),
+				"strict": true,
+			},
+		},
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIBase+"/chat/completions", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suggestionHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openai status %s", resp.Status)
+	}
+
+	var openaiResp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&openaiResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if len(openaiResp.Choices) == 0 {
+		return nil, fmt.Errorf("no choices returned")
+	}
+
+	var out suggestionSchema
+	if err := json.Unmarshal([]byte(openaiResp.Choices[0].Message.Content), &out); err != nil {
+		return nil, fmt.Errorf("unmarshal structured output: %w", err)
+	}
+	return out.Unverified, nil
+}
+
+// writeSuggestionsFile writes the suggested domains to path in the
+// ExtendedGroupedData format.
+func writeSuggestionsFile(path string, list []DomainRecord) error {
+	data := ExtendedGroupedData{Unverified: list}
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0644)
+}

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -1,0 +1,117 @@
+package talia
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// fakeHTTPClient implements the Do method for testing.
+type fakeHTTPClient struct{ srv *httptest.Server }
+
+func (f fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	rr := httptest.NewRecorder()
+	f.srv.Config.Handler.ServeHTTP(rr, req)
+	return rr.Result(), nil
+}
+
+// TestGenerateDomainSuggestionsSuccess verifies we parse suggestions correctly.
+func TestGenerateDomainSuggestionsSuccess(t *testing.T) {
+	// fake OpenAI server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// return structured output JSON
+		io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"choices":[{"message":{"content":"{\"unverified\":[{\"domain\":\"a.com\"}]}"}}]}`)
+	}))
+	defer srv.Close()
+
+	suggestionHTTPClient = fakeHTTPClient{srv}
+	openAIBase = srv.URL
+	t.Cleanup(func() {
+		suggestionHTTPClient = http.DefaultClient
+		openAIBase = "https://api.openai.com/v1"
+	})
+
+	got, err := GenerateDomainSuggestions("key", "", 1)
+	if err != nil {
+		t.Fatalf("GenerateDomainSuggestions returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].Domain != "a.com" {
+		t.Fatalf("unexpected suggestions: %+v", got)
+	}
+}
+
+func TestGenerateDomainSuggestionsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	suggestionHTTPClient = fakeHTTPClient{srv}
+	openAIBase = srv.URL
+	t.Cleanup(func() {
+		suggestionHTTPClient = http.DefaultClient
+		openAIBase = "https://api.openai.com/v1"
+	})
+
+	_, err := GenerateDomainSuggestions("key", "", 1)
+	if err == nil {
+		t.Fatal("expected error on HTTP 500")
+	}
+}
+
+func TestRunCLISuggest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"choices":[{"message":{"content":"{\"unverified\":[{\"domain\":\"b.com\"}]}"}}]}`)
+	}))
+	defer srv.Close()
+
+	suggestionHTTPClient = fakeHTTPClient{srv}
+	openAIBase = srv.URL
+	t.Cleanup(func() {
+		suggestionHTTPClient = http.DefaultClient
+		openAIBase = "https://api.openai.com/v1"
+	})
+
+	tmp, err := os.CreateTemp("", "sugg_*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	defer helperRemove(t, tmp.Name())
+
+	os.Setenv("OPENAI_API_KEY", "key")
+	defer os.Unsetenv("OPENAI_API_KEY")
+
+	stdout, stderr := captureOutput(t, func() {
+		code := RunCLI([]string{"--suggest=1", tmp.Name()})
+		if code != 0 {
+			t.Errorf("expected exit 0, got %d", code)
+		}
+	})
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+	if !strings.Contains(stdout, "Wrote domain suggestions") {
+		t.Errorf("missing success message: %s", stdout)
+	}
+
+	raw, _ := os.ReadFile(tmp.Name())
+	var out ExtendedGroupedData
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(out.Unverified) != 1 || out.Unverified[0].Domain != "b.com" {
+		t.Fatalf("unexpected file contents: %+v", out)
+	}
+}


### PR DESCRIPTION
## Summary
- generate domain suggestions via OpenAI structured output
- add `--suggest` and `--prompt` flags
- document domain suggestion usage
- implement HTTP-based OpenAI client with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683d12164c1c8327925703cbaec141e8