### PR TITLE
Add commit linting and release config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [2, "always", ["feat", "fix", "chore", "docs", "refactor", "test", "perf", "style", "revert"]]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,18 @@ name: CI
 on:
   push:
     branches: ["*"]
+  pull_request:
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Lint Commits
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.json
 
       - uses: actions/setup-go@v5
         with:

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,10 @@
+{
+  "release-type": "simple",
+  "include-v-in-tag": true,
+  "pull-request-title-pattern": "chore${scope}: release ${version}",
+  "changelog-types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "section": "Miscellaneous" }
+  ]
+}

--- a/README.MD
+++ b/README.MD
@@ -264,3 +264,12 @@ Talia's test suite covers:
 - **`--grouped-output`**: Switch to grouped output
 - **`--output-file=<path>`**: If provided, Talia merges/writes grouped JSON to this file and leaves the input alone
 - **Input JSON**: The file containing an array of domain objects or a grouped object with unverified domains
+
+---
+
+## Contributing
+
+Pull requests are welcome. All commits must follow the Conventional Commits
+specification so that automated release tooling can parse them correctly.
+A commit lint check runs in CI to enforce this format. Example prefix types
+include `feat`, `fix`, `chore`, and `docs`.


### PR DESCRIPTION
## Summary
- lint commits with commitlint in CI
- configure commit types for release-please
- document the commit requirement in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683e5d1a5e80832783e0685d48a6152f