### PR TITLE
Allow CLI to select OpenAI model

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -186,11 +186,14 @@ func RunCLI(args []string) int {
 	outputFile := fs.String("output-file", "", "Path to grouped output file (if set, input file remains unmodified)")
 	suggest := fs.Int("suggest", 0, "Number of domain suggestions to generate (if >0, no WHOIS checks are run)")
 	prompt := fs.String("prompt", "", "Optional prompt to influence domain suggestions")
+	model := fs.String("openai-model", defaultOpenAIModel, "OpenAI model to use for suggestions")
 
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintln(os.Stderr, "Error parsing flags:", err)
 		return 1
 	}
+
+	openAIModel = *model
 
 	if fs.NArg() < 1 {
 		fmt.Fprintf(os.Stderr, "Usage: %s --whois=<server:port> [--sleep=2s] [--verbose] [--grouped-output] [--output-file=path] <json-file>\n", fs.Name())

--- a/suggestions.go
+++ b/suggestions.go
@@ -13,7 +13,7 @@ const (
 	defaultOpenAIBase  = "https://api.openai.com/v1"
 	systemPrompt       = "You generate domain name ideas. All domain names must end with .com. Do not return any domain without .com."
 	userPromptTemplate = "%s Return %d unique domain suggestions in the 'unverified' array. Each domain must end with .com. Do not return any domain without .com."
-	openAIModel        = "gpt-4o"
+	defaultOpenAIModel = "gpt-4o"
 	functionName       = "suggest_domains"
 	functionDesc       = "Generate domain name ideas."
 )
@@ -34,6 +34,7 @@ type httpDoer interface {
 var (
 	suggestionHTTPClient httpDoer = http.DefaultClient
 	openAIBase                    = defaultOpenAIBase
+	openAIModel                   = defaultOpenAIModel
 )
 
 // GenerateDomainSuggestions contacts the OpenAI API using structured output

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -126,3 +126,56 @@ func TestRunCLISuggest(t *testing.T) {
 		t.Fatalf("unexpected file contents: %+v", out)
 	}
 }
+
+func TestRunCLISuggestModelFlag(t *testing.T) {
+	var gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		_ = json.Unmarshal(b, &payload)
+		if v, ok := payload["model"].(string); ok {
+			gotModel = v
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"function_call":{"name":"suggest_domains","arguments":"{\"unverified\":[{\"domain\":\"c.com\"}]}"}}}]}`)
+	}))
+	defer srv.Close()
+
+	suggestionHTTPClient = fakeHTTPClient{srv}
+	openAIBase = srv.URL
+	t.Cleanup(func() {
+		suggestionHTTPClient = http.DefaultClient
+		openAIBase = "https://api.openai.com/v1"
+		openAIModel = defaultOpenAIModel
+	})
+
+	tmp, err := os.CreateTemp("", "sugg_model_*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("tmp.Close() error: %v", err)
+	}
+	defer helperRemove(t, tmp.Name())
+
+	if err := os.Setenv("OPENAI_API_KEY", "key"); err != nil {
+		t.Fatalf("os.Setenv error: %v", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("OPENAI_API_KEY"); err != nil {
+			t.Fatalf("os.Unsetenv error: %v", err)
+		}
+	}()
+
+	_, _ = captureOutput(t, func() {
+		code := RunCLI([]string{"--suggest=1", "--openai-model=my-model", tmp.Name()})
+		if code != 0 {
+			t.Errorf("expected exit 0, got %d", code)
+		}
+	})
+
+	if gotModel != "my-model" {
+		t.Fatalf("server received model %q, want %q", gotModel, "my-model")
+	}
+}


### PR DESCRIPTION
## Summary
- allow specifying which OpenAI model is used when generating suggestions
- add `--openai-model` flag to CLI
- expose model through internal variable for suggestions
- test that the flag modifies the model used

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683e619caffc832783f9e04ef24f33ae