### PR TITLE
docs: implement structured documentation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work.sum
 tmp/
 
 talia
+talia-bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,40 +1,37 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Talia is a CLI tool for checking `.com` domain availability via WHOIS and generating domain suggestions via OpenAI-compatible APIs. All source lives in the root `talia` package with a thin binary wrapper at `cmd/talia/main.go`. Uses Conventional Commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `style`, `revert`).
 
-## Build & Development Commands
+## Quick Commands
 
 ```bash
-# Build the binary
-go build -o talia
-
-# Run tests
-go test -v
-
-# Run tests with race detection and coverage
-go test -race -coverprofile=coverage.out ./...
-go tool cover -func=coverage.out
-
-# Lint (uses Go tool directive - auto-downloads on first run)
-go tool golangci-lint run
+go build -o talia              # build
+go test -v                     # test
+go test -race -coverprofile=coverage.out ./...  # test with race + coverage
+go tool golangci-lint run      # lint
 ```
 
-## Architecture
+## Documentation
 
-Talia is a CLI tool for checking domain availability via WHOIS servers and generating domain suggestions via OpenAI.
+Full docs live in [`docs/`](docs/README.md):
 
-**Core modules (root package `talia`):**
+### Decisions (architecture rationale)
+- [001 — WHOIS Availability Detection](docs/decisions/001-whois-availability-detection.md)
+- [002 — AI Suggestion Architecture](docs/decisions/002-ai-suggestion-architecture.md)
+- [003 — Parallel Processing Design](docs/decisions/003-parallel-processing-design.md)
+- [004 — Output Format Design](docs/decisions/004-output-format-design.md)
 
-- **cli.go** - Entry point with flag parsing. `RunCLI()` routes to either `RunCLIDomainArray()` (plain array format) or `RunCLIGroupedInput()` (grouped format with unverified domains)
-- **whois.go** - WHOIS client using TCP sockets. `WhoisClient` interface enables testing with mock implementations. Availability detected by "No match for" substring
-- **types.go** - Data structures: `DomainRecord` (array format), `GroupedDomain`/`GroupedData`/`ExtendedGroupedData` (grouped format)
-- **grouped.go** - JSON merge logic for grouped output format with deduplication
-- **suggestions.go** - OpenAI-compatible API integration using structured output for domain generation. Supports OpenAI, Gemini, and other compatible APIs via `--api-base` flag or `OPENAI_API_BASE` env var (requires `OPENAI_API_KEY`)
+### Features (behavior specs)
+- [Domain Checking](docs/features/domain-checking.md) — WHOIS-based availability verification
+- [AI Suggestions](docs/features/ai-suggestions.md) — AI-powered domain name generation
+- [File Cleaning](docs/features/file-cleaning.md) — domain normalization and deduplication
+- [Merge and Export](docs/features/merge-and-export.md) — file merging and plain text export
+- [Parallel Processing](docs/features/parallel-processing.md) — concurrent WHOIS and suggestion requests
 
-**cmd/talia/main.go** - Thin wrapper that calls `talia.RunCLI()`
+### Guides (development and operations)
+- [Development Guide](docs/guides/development.md) — building, running, and contributing
+- [Configuration Reference](docs/guides/configuration.md) — all flags, env vars, and `.env` support
+- [Testing Guide](docs/guides/testing.md) — test architecture, mocking, and CI
 
-## Commit Convention
-
-Uses Conventional Commits (enforced by commitlint in CI). Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `style`, `revert`.
-
-Example: `feat: add new flag for TLD filtering`
+### Plans (open risks)
+- [Known Issues](docs/plans/known-issues.md) — quirks and limitations

--- a/README.MD
+++ b/README.MD
@@ -96,8 +96,8 @@ Talia can generate domain name suggestions using AI, check domain availability v
 
 ### Prerequisites
 
-- Go 1.16 or later
-- golangci‑lint v2.1.6 (declared as a Go tool; Go 1.24+ will auto‑build it on first use)
+- Go 1.24.3 or later (uses `tool` directive in `go.mod`)
+- golangci-lint v2.8.0 (declared as a Go tool; auto-downloads on first use)
 
 ### Steps
 
@@ -369,6 +369,10 @@ Talia's test suite covers:
 - **Input JSON**: The file containing an array of domain objects or a grouped object with unverified domains (can also be set via `TALIA_FILE` env var)
 
 ---
+
+## Documentation
+
+For detailed architecture decisions, feature specs, configuration reference, and development guides, see the [docs/](docs/README.md) directory.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ docs/
     development.md
     configuration.md
     testing.md
+    documentation-system-playbook.md
   plans/                             # open risks and known issues
     known-issues.md
   templates/                         # authoring skeletons
@@ -61,6 +62,7 @@ docs/
 - [Development Guide](guides/development.md) — building, running, and contributing
 - [Configuration Reference](guides/configuration.md) — all flags, env vars, and `.env` support
 - [Testing Guide](guides/testing.md) — test architecture, mocking, and CI
+- [Documentation System Playbook](guides/documentation-system-playbook.md) — universal docs architecture guide
 
 ## Plans
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,84 @@
+# Talia Documentation
+
+Documentation index for the Talia CLI — a domain availability checker and AI-powered domain suggestion tool.
+
+## Structure
+
+```text
+docs/
+  README.md                          # this file — master index
+  decisions/                         # architecture and technical rationale
+    001-whois-availability-detection.md
+    002-ai-suggestion-architecture.md
+    003-parallel-processing-design.md
+    004-output-format-design.md
+  features/                          # product behavior and rules
+    domain-checking.md
+    ai-suggestions.md
+    file-cleaning.md
+    merge-and-export.md
+    parallel-processing.md
+  guides/                            # development and operations
+    development.md
+    configuration.md
+    testing.md
+  plans/                             # open risks and known issues
+    known-issues.md
+  templates/                         # authoring skeletons
+    decision-record.md
+    feature-spec.md
+    guide.md
+    plan.md
+```
+
+## Doc Type Taxonomy
+
+| Question | Folder |
+|---|---|
+| Why did we choose this architecture? | [decisions/](decisions/) |
+| How should the feature behave? | [features/](features/) |
+| How do I develop, configure, or test? | [guides/](guides/) |
+| What is pending, risky, or open? | [plans/](plans/) |
+| How do I author a new doc? | [templates/](templates/) |
+
+## Decision Records
+
+- [001 — WHOIS Availability Detection](decisions/001-whois-availability-detection.md)
+- [002 — AI Suggestion Architecture](decisions/002-ai-suggestion-architecture.md)
+- [003 — Parallel Processing Design](decisions/003-parallel-processing-design.md)
+- [004 — Output Format Design](decisions/004-output-format-design.md)
+
+## Feature Specs
+
+- [Domain Checking](features/domain-checking.md) — WHOIS-based availability verification
+- [AI Suggestions](features/ai-suggestions.md) — AI-powered domain name generation
+- [File Cleaning](features/file-cleaning.md) — domain normalization and deduplication
+- [Merge and Export](features/merge-and-export.md) — file merging and plain text export
+- [Parallel Processing](features/parallel-processing.md) — concurrent WHOIS and suggestion requests
+
+## Guides
+
+- [Development Guide](guides/development.md) — building, running, and contributing
+- [Configuration Reference](guides/configuration.md) — all flags, env vars, and `.env` support
+- [Testing Guide](guides/testing.md) — test architecture, mocking, and CI
+
+## Plans
+
+- [Known Issues](plans/known-issues.md) — open risks and quirks
+
+## Authoring Rules
+
+1. One primary topic per file.
+2. Stable heading hierarchy (`#`, then `##` for key sections).
+3. Use relative links for local navigation.
+4. Add a `Related Documentation` section near the end.
+5. Use explicit dates (`YYYY-MM-DD`) when time matters.
+6. Prefer bullet constraints over long prose when defining rules.
+7. Keep examples concrete (paths, commands, model names, flows).
+
+## Maintenance
+
+- Update affected docs in the same PR as code changes.
+- If architecture changed, update `decisions/` first, then link from feature docs.
+- If behavior changed, update `features/` and related guides.
+- Run markdown link validation after structural changes.

--- a/docs/decisions/001-whois-availability-detection.md
+++ b/docs/decisions/001-whois-availability-detection.md
@@ -1,0 +1,36 @@
+# ADR-001: WHOIS Availability Detection
+
+**Date:** 2025-05-29
+**Status:** Accepted
+
+## Context
+
+Talia needs to determine whether a domain name is available for registration. The standard protocol for this is WHOIS, which returns free-text responses with no universal format across registries.
+
+## Decision
+
+Use a single substring match — `"No match for"` — against the raw WHOIS response to determine availability.
+
+- **Available:** response contains `"No match for"` → `NO_MATCH`
+- **Taken:** response does not contain the substring → `TAKEN`
+- **Error:** TCP connection failure or empty response → `ERROR`
+
+The tool uses raw TCP sockets (`net.Dial`) rather than an HTTP-based WHOIS API. The connection writes `"<domain>\r\n"`, calls `CloseWrite()` to signal EOF, and reads the full response with `io.ReadAll`.
+
+## Alternatives Considered
+
+1. **Registry-specific parsers per TLD** — more accurate but high maintenance cost and scope creep.
+2. **RDAP (Registration Data Access Protocol)** — structured JSON responses, but not universally supported across all registrars and adds HTTP dependency.
+3. **Third-party WHOIS APIs** — adds external dependency, rate limits, and potential cost.
+
+## Consequences
+
+- **Pro:** Simple, zero-dependency, works reliably with Verisign-style servers (`.com`, `.net`).
+- **Pro:** The `WhoisClient` interface makes it trivial to swap implementations later.
+- **Con:** The `"No match for"` string is specific to Verisign WHOIS servers. Other registries (e.g., `.io`, `.dev`) use different phrasing and will report all domains as taken.
+- **Con:** No retry logic — transient TCP failures are reported as `ERROR` and processing continues.
+
+## Related Documentation
+
+- [Domain Checking](../features/domain-checking.md)
+- [Configuration Reference](../guides/configuration.md)

--- a/docs/decisions/002-ai-suggestion-architecture.md
+++ b/docs/decisions/002-ai-suggestion-architecture.md
@@ -40,4 +40,5 @@ Key design choices:
 ## Related Documentation
 
 - [AI Suggestions](../features/ai-suggestions.md)
+- [Parallel Processing](../features/parallel-processing.md)
 - [Configuration Reference](../guides/configuration.md)

--- a/docs/decisions/002-ai-suggestion-architecture.md
+++ b/docs/decisions/002-ai-suggestion-architecture.md
@@ -1,0 +1,43 @@
+# ADR-002: AI Suggestion Architecture
+
+**Date:** 2025-05-29
+**Status:** Accepted
+
+## Context
+
+Talia needs to generate creative domain name suggestions. Rather than using hardcoded word lists or algorithmic generation, the tool leverages large language models via the OpenAI-compatible chat completions API.
+
+## Decision
+
+Use the OpenAI **tool-calling (function calling)** API format to enforce structured output.
+
+Key design choices:
+
+1. **Tool calling over `response_format`** — A single tool named `suggest_domains` is defined with a JSON schema. The model is forced to call it via `tool_choice`, guaranteeing structured output regardless of model provider.
+
+2. **OpenAI-compatible API** — The `--api-base` flag (or `OPENAI_API_BASE` env var) allows pointing to any compatible endpoint (OpenAI, Gemini, local models), making the tool provider-agnostic.
+
+3. **`.com` only** — The system prompt and `normalizeDomain()` validation both enforce `.com` TLD exclusively. This is a deliberate constraint to keep the tool focused.
+
+4. **Exclusion list** — Existing domains from the file are passed to the AI as "do not suggest these" (unless `--fresh` is set), reducing duplicates at the prompt level.
+
+5. **Post-generation deduplication** — `writeSuggestionsFile()` also deduplicates against the full file contents, catching anything the model still repeats.
+
+## Alternatives Considered
+
+1. **Structured output via `response_format`** — Less portable across providers; tool calling is more widely supported.
+2. **Embedding-based similarity search** — Over-engineered for name generation; doesn't leverage model creativity.
+3. **Multi-TLD support** — Increases complexity significantly (different WHOIS servers per TLD, validation rules). Deferred.
+
+## Consequences
+
+- **Pro:** Works with OpenAI, Gemini, and any OpenAI-compatible API out of the box.
+- **Pro:** Structured output is guaranteed by the tool-calling contract.
+- **Pro:** Deduplication happens at two levels (prompt exclusion + file-level seen map).
+- **Con:** Parallel requests all receive the same exclusion list (pre-run snapshot), so they may generate overlapping suggestions. File-level dedup catches this.
+- **Con:** Hardcoded to `.com` — extending to other TLDs requires changes in both the prompt and validation logic.
+
+## Related Documentation
+
+- [AI Suggestions](../features/ai-suggestions.md)
+- [Configuration Reference](../guides/configuration.md)

--- a/docs/decisions/003-parallel-processing-design.md
+++ b/docs/decisions/003-parallel-processing-design.md
@@ -1,0 +1,51 @@
+# ADR-003: Parallel Processing Design
+
+**Date:** 2026-01-20
+**Status:** Accepted
+
+## Context
+
+Sequential WHOIS checking with a 2-second sleep between requests is reliable but slow for large domain lists. Similarly, generating many AI suggestions benefits from concurrent API calls.
+
+## Decision
+
+Implement two independent parallelism mechanisms:
+
+### Parallel WHOIS (`--lightspeed`)
+
+- Uses a **worker pool** with a buffered channel of jobs.
+- Workers drain the channel and write results to a **pre-indexed slice** (`results[job.index]`), preserving input order.
+- Three modes:
+  - `"max"` → one goroutine per domain (capped to `len(domains)`)
+  - Integer string (e.g., `"10"`) → fixed worker count
+  - Invalid string → defaults silently to 10 workers
+- Sleep between checks is skipped entirely in parallel mode.
+- Progress output is mutex-protected to prevent interleaved lines.
+- Statistics use `atomic.AddInt64` for lock-free counter increments.
+
+### Parallel Suggestions (`--suggest-parallel`)
+
+- All N goroutines launch simultaneously (no worker pool — each fires one HTTP request).
+- Results are accumulated under a `sync.Mutex` into a shared `allResults` slice.
+- Partial failure is tolerated: if some requests succeed and others fail, a warning is printed and partial results are used.
+- Deduplication across parallel responses happens in `writeSuggestionsFile()` after all goroutines complete.
+
+## Alternatives Considered
+
+1. **Rate-limited parallel** — Add configurable rate limiting to parallel WHOIS. Deferred; users can control concurrency via the worker count.
+2. **Streaming results** — Write results as they arrive instead of collecting all first. Adds complexity for minimal user benefit since the file is written atomically.
+3. **Context-aware parallel suggestions** — Pass results from earlier parallel requests as exclusions to later ones. Would serialize requests and defeat the purpose.
+
+## Consequences
+
+- **Pro:** Pre-indexed result slice guarantees deterministic output order regardless of goroutine scheduling.
+- **Pro:** Atomic counters and mutex-protected printing are race-detector clean.
+- **Pro:** Partial failure handling for suggestions avoids losing all results due to one bad request.
+- **Con:** Invalid `--lightspeed` values default silently to 10 — no warning is emitted.
+- **Con:** `"max"` mode with thousands of domains will open that many TCP connections simultaneously, which may trigger WHOIS server rate limiting.
+
+## Related Documentation
+
+- [Parallel Processing](../features/parallel-processing.md)
+- [Domain Checking](../features/domain-checking.md)
+- [AI Suggestions](../features/ai-suggestions.md)

--- a/docs/decisions/004-output-format-design.md
+++ b/docs/decisions/004-output-format-design.md
@@ -76,3 +76,4 @@ Used only for `--export-available` output and as an alternative `--clean` input.
 - [Domain Checking](../features/domain-checking.md)
 - [AI Suggestions](../features/ai-suggestions.md)
 - [Merge and Export](../features/merge-and-export.md)
+- [File Cleaning](../features/file-cleaning.md)

--- a/docs/decisions/004-output-format-design.md
+++ b/docs/decisions/004-output-format-design.md
@@ -1,0 +1,78 @@
+# ADR-004: Output Format Design
+
+**Date:** 2025-05-29
+**Status:** Accepted
+
+## Context
+
+Talia needs to persist domain checking results. The tool supports multiple workflows — simple batch checking, AI-driven suggestion pipelines, and file merging — each with different output needs.
+
+## Decision
+
+Support three output formats, with auto-detection on input:
+
+### 1. Array Format (default)
+
+```json
+[
+  {"domain": "example.com", "available": true, "reason": "NO_MATCH"},
+  {"domain": "taken.com", "available": false, "reason": "TAKEN"}
+]
+```
+
+- Input file is updated in place.
+- Fields `available`, `reason`, and `log` are `omitempty`.
+- `log` only populated when `--verbose` is set or `reason == "ERROR"`.
+
+### 2. Grouped Format (`--grouped-output`)
+
+```json
+{
+  "available": [{"domain": "example.com", "reason": "NO_MATCH"}],
+  "unavailable": [{"domain": "taken.com", "reason": "TAKEN"}]
+}
+```
+
+- Uses `GroupedDomain` type (always includes `reason`).
+- With `--output-file`, leaves the input file untouched and writes/merges to the specified output.
+
+### 3. Extended Grouped Format (suggestion workflow)
+
+```json
+{
+  "available": [...],
+  "unavailable": [...],
+  "unverified": [{"domain": "new-suggestion.com"}]
+}
+```
+
+- The `unverified` array holds AI-generated suggestions pending WHOIS verification.
+- After verification, domains move to `available`/`unavailable` and `unverified` is set to `nil` (omitted from JSON via `omitempty`).
+- A single file represents all workflow states without format changes.
+
+### Input auto-detection
+
+`RunCLI` tries `json.Unmarshal` into `[]DomainRecord` first (array), then `ExtendedGroupedData` (object). The JSON structure itself determines the code path — no flag needed.
+
+### Plain text
+
+Used only for `--export-available` output and as an alternative `--clean` input. One domain per line, no JSON wrapper.
+
+## Alternatives Considered
+
+1. **Single format only** — Simpler but forces all users into one workflow. The grouped format is essential for the suggestion pipeline.
+2. **YAML or TOML** — JSON is simpler, has native Go support, and works directly with `jq` and other CLI tools.
+3. **Database (SQLite)** — Over-engineered for a CLI tool that processes files.
+
+## Consequences
+
+- **Pro:** `ExtendedGroupedData` with `omitempty` elegantly represents the full suggestion→verify lifecycle in one file.
+- **Pro:** Auto-detection means users never need to specify the format — the tool just works.
+- **Con:** Two merge implementations exist (`mergeGrouped` in `grouped.go` and `mergeFiles` in `suggestions.go`) with different semantics. See [Known Issues](../plans/known-issues.md).
+- **Con:** `mergeGrouped` uses map iteration, producing non-deterministic JSON key ordering on each run.
+
+## Related Documentation
+
+- [Domain Checking](../features/domain-checking.md)
+- [AI Suggestions](../features/ai-suggestions.md)
+- [Merge and Export](../features/merge-and-export.md)

--- a/docs/features/ai-suggestions.md
+++ b/docs/features/ai-suggestions.md
@@ -1,0 +1,67 @@
+# AI Suggestions
+
+AI-powered domain name generation via OpenAI-compatible APIs.
+
+## Overview
+
+Talia generates domain name suggestions by calling a large language model through the OpenAI chat completions API. It uses tool calling (function calling) to enforce structured JSON output, and supports any OpenAI-compatible endpoint.
+
+## How It Works
+
+1. **Read existing domains** from the target file (all three sections: available, unavailable, unverified).
+2. **Build the prompt** with the user's `--prompt` text, the requested count (`--suggest`), and an exclusion list of existing domains (unless `--fresh` is set).
+3. **Call the API** using a tool named `suggest_domains` with `tool_choice` forced, ensuring the model returns structured JSON.
+4. **Parse the response** from `choices[0].message.tool_calls[0].function.arguments`.
+5. **Normalize and deduplicate** each suggestion via `normalizeDomain()`, then append only new domains to the `unverified` array.
+6. **Auto-verify** (optional): if a WHOIS server is configured and `--no-verify` is not set, immediately run WHOIS checks on the new suggestions.
+
+## Prompt Structure
+
+**System prompt:**
+```
+You generate domain name ideas. All domain names must end with .com. Do not return any domain without .com.
+```
+
+**User prompt (with exclusions):**
+```
+<user prompt> Return <N> unique domain suggestions in the 'unverified' array. Each domain must end with .com. Do not return any domain without .com. Do NOT suggest any of these existing domains: <comma-separated list>
+```
+
+## Domain Normalization
+
+Every suggestion passes through `normalizeDomain()` which:
+
+- Lowercases and trims whitespace
+- Strips repeated `.com.com` suffixes
+- Collapses double dots (`..` → `.`)
+- Rejects domains not ending in `.com`
+- Rejects domains with more than two dot-separated parts (no subdomains)
+- Validates the label with `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` (no special chars, no leading/trailing hyphens)
+
+## Parallel Requests
+
+`--suggest-parallel N` fires N concurrent API requests simultaneously, each requesting the same count. Results are merged and deduplicated after all complete. See [Parallel Processing](parallel-processing.md).
+
+## Auto-Verification
+
+After suggestions are written, if a WHOIS server is configured and `--no-verify` is not set, the tool automatically calls `RunCLIGroupedInput()` with a 100ms sleep to verify the unverified domains via WHOIS.
+
+## `TALIA_SUGGEST` Env Var Behavior
+
+If `--suggest` is not set explicitly but `TALIA_SUGGEST` is in the environment:
+- **Used** if the target file has no pending `unverified` domains.
+- **Ignored** if the file already has `unverified` entries (prevents double-suggesting mid-workflow).
+- The explicit `--suggest` flag always fires regardless.
+
+## Limitations
+
+- Hardcoded to `.com` domains only (enforced in both the prompt and validation).
+- Parallel requests receive the same exclusion list (pre-run snapshot), so they may return overlapping suggestions. File-level dedup resolves this.
+- The default model (`gpt-5-mini`) must be overridden via `--model` or `TALIA_MODEL` if it doesn't match your provider's model catalog.
+
+## Related Documentation
+
+- [ADR-002: AI Suggestion Architecture](../decisions/002-ai-suggestion-architecture.md)
+- [Parallel Processing](parallel-processing.md)
+- [Configuration Reference](../guides/configuration.md)
+- [Domain Checking](domain-checking.md)

--- a/docs/features/ai-suggestions.md
+++ b/docs/features/ai-suggestions.md
@@ -12,7 +12,7 @@ Talia generates domain name suggestions by calling a large language model throug
 2. **Build the prompt** with the user's `--prompt` text, the requested count (`--suggest`), and an exclusion list of existing domains (unless `--fresh` is set).
 3. **Call the API** using a tool named `suggest_domains` with `tool_choice` forced, ensuring the model returns structured JSON.
 4. **Parse the response** from `choices[0].message.tool_calls[0].function.arguments`.
-5. **Normalize and deduplicate** each suggestion via `normalizeDomain()`, then append only new domains to the `unverified` array.
+5. **Normalize and deduplicate** via `writeSuggestionsFile()` — reads the existing file, builds a `seen` map from all three sections (available, unavailable, unverified), normalizes each suggestion with `normalizeDomain()`, and appends only truly new valid domains to the `unverified` array. Existing entries are preserved untouched.
 6. **Auto-verify** (optional): if a WHOIS server is configured and `--no-verify` is not set, immediately run WHOIS checks on the new suggestions.
 
 ## Prompt Structure
@@ -44,14 +44,19 @@ Every suggestion passes through `normalizeDomain()` which:
 
 ## Auto-Verification
 
-After suggestions are written, if a WHOIS server is configured and `--no-verify` is not set, the tool automatically calls `RunCLIGroupedInput()` with a 100ms sleep to verify the unverified domains via WHOIS.
+After suggestions are written, if a WHOIS server is configured and `--no-verify` is not set, the tool automatically verifies the unverified domains via WHOIS.
+
+- Uses a hardcoded 100ms sleep between sequential checks (not the user's `--sleep` value).
+- If `--lightspeed` is set, parallel workers are passed through to the verification step.
+- Verification moves domains from `unverified` into `available` or `unavailable`.
 
 ## `TALIA_SUGGEST` Env Var Behavior
 
 If `--suggest` is not set explicitly but `TALIA_SUGGEST` is in the environment:
-- **Used** if the target file has no pending `unverified` domains.
-- **Ignored** if the file already has `unverified` entries (prevents double-suggesting mid-workflow).
-- The explicit `--suggest` flag always fires regardless.
+- The file is parsed as `ExtendedGroupedData` to check for pending suggestions.
+- **Used** if the file has no pending `unverified` domains (or isn't grouped format).
+- **Ignored** if the file already has a non-empty `unverified` array (prevents double-suggesting mid-workflow).
+- The explicit `--suggest` flag always fires regardless of `unverified` state.
 
 ## Limitations
 

--- a/docs/features/domain-checking.md
+++ b/docs/features/domain-checking.md
@@ -11,7 +11,8 @@ Talia checks domain availability by connecting to a WHOIS server over raw TCP an
 1. Opens a TCP connection to the configured `--whois` server (e.g., `whois.verisign-grs.com:43`).
 2. Sends `"<domain>\r\n"` and half-closes the write side (`CloseWrite`) to signal EOF.
 3. Reads the full response with `io.ReadAll`.
-4. Checks for the substring `"No match for"` in the response:
+4. Handles connection errors gracefully — `connection reset by peer`, `broken pipe`, and `connection closed` are normalized to an `"empty WHOIS response"` error rather than exposing raw TCP errors.
+5. Checks for the substring `"No match for"` in the response:
    - **Found** → domain is available (`NO_MATCH`)
    - **Not found** → domain is taken (`TAKEN`)
    - **Connection error or empty response** → `ERROR`
@@ -46,7 +47,7 @@ Each domain check prints a line to stdout:
 [3/50] broken.com ⚠ error
 ```
 
-In parallel mode, output lines are mutex-protected to prevent interleaving. A summary with counts and elapsed time is printed after all checks complete.
+In parallel mode, output lines are mutex-protected to prevent interleaving. A summary with counts and elapsed time is printed after all checks complete. Zero-count categories are suppressed from the summary. ANSI color codes are used unconditionally (no TTY detection — raw escape codes will appear if output is piped or redirected).
 
 ## Limitations
 

--- a/docs/features/domain-checking.md
+++ b/docs/features/domain-checking.md
@@ -1,0 +1,61 @@
+# Domain Checking
+
+WHOIS-based domain availability verification.
+
+## Overview
+
+Talia checks domain availability by connecting to a WHOIS server over raw TCP and interpreting the response. Domains are classified as available (`NO_MATCH`), taken (`TAKEN`), or errored (`ERROR`).
+
+## How It Works
+
+1. Opens a TCP connection to the configured `--whois` server (e.g., `whois.verisign-grs.com:43`).
+2. Sends `"<domain>\r\n"` and half-closes the write side (`CloseWrite`) to signal EOF.
+3. Reads the full response with `io.ReadAll`.
+4. Checks for the substring `"No match for"` in the response:
+   - **Found** → domain is available (`NO_MATCH`)
+   - **Not found** → domain is taken (`TAKEN`)
+   - **Connection error or empty response** → `ERROR`
+
+## Input Formats
+
+The tool auto-detects the input format:
+
+- **Array format** — `[]DomainRecord` (JSON array of objects with `domain` field)
+- **Extended grouped format** — `ExtendedGroupedData` (JSON object with `available`, `unavailable`, `unverified` arrays)
+
+See [Output Format Design](../decisions/004-output-format-design.md) for format details.
+
+## Sequential vs Parallel
+
+- **Sequential** (default): checks one domain at a time with `--sleep` delay (default `2s`) between requests.
+- **Parallel** (`--lightspeed`): uses a worker pool for concurrent checks. See [Parallel Processing](parallel-processing.md).
+
+## Error Handling
+
+- Errors do not abort the run. A failed domain gets `available=false`, `reason=ERROR`, and the error message in the `log` field.
+- The exit code is `0` as long as the file write succeeds.
+- The `log` field is populated for errors regardless of `--verbose`. For successful checks, `log` only appears when `--verbose` is set.
+
+## Progress Output
+
+Each domain check prints a line to stdout:
+
+```
+[1/50] example.com ✓ available
+[2/50] taken.com ✗ taken
+[3/50] broken.com ⚠ error
+```
+
+In parallel mode, output lines are mutex-protected to prevent interleaving. A summary with counts and elapsed time is printed after all checks complete.
+
+## Limitations
+
+- The `"No match for"` detection string is specific to Verisign-style WHOIS servers (`.com`, `.net`). Other registries use different phrasing and will report all domains as taken.
+- No TLD routing — a single WHOIS server is used for all domains in the file.
+- No retry logic for transient TCP failures.
+
+## Related Documentation
+
+- [ADR-001: WHOIS Availability Detection](../decisions/001-whois-availability-detection.md)
+- [Parallel Processing](parallel-processing.md)
+- [Configuration Reference](../guides/configuration.md)

--- a/docs/features/file-cleaning.md
+++ b/docs/features/file-cleaning.md
@@ -1,0 +1,62 @@
+# File Cleaning
+
+Domain normalization, validation, and deduplication for JSON and plain text files.
+
+## Overview
+
+The `--clean` flag normalizes and removes invalid domains from a file, then exits. It auto-detects whether the file is JSON or plain text.
+
+## Format Auto-Detection
+
+The file content is tested with `json.Valid()`:
+- **Valid JSON** → `cleanSuggestionsFile()` — processes `ExtendedGroupedData`
+- **Not valid JSON** → `cleanTextFile()` — processes line-by-line plain text
+
+## JSON Cleaning (`cleanSuggestionsFile`)
+
+1. Parses the file as `ExtendedGroupedData`.
+2. Runs every domain through `normalizeDomain()`.
+3. Removes domains that fail validation.
+4. Deduplicates across all three sections using a `seen` map. Processing order: available → unavailable → unverified. A domain appearing in both `available` and `unverified` keeps the `available` entry.
+5. Writes back the cleaned structure.
+
+## Plain Text Cleaning (`cleanTextFile`)
+
+1. Reads the file line by line.
+2. Skips blank lines and lines starting with `#`.
+3. Runs each line through `normalizeDomain()`.
+4. Deduplicates (first occurrence wins).
+5. Writes back as newline-joined list with a trailing newline.
+6. Order is preserved from input (minus removed entries). Output is not sorted.
+
+## Validation Rules (`normalizeDomain`)
+
+| Rule | Example |
+|---|---|
+| Lowercase and trim whitespace | `" Example.COM "` → `"example.com"` |
+| Strip repeated `.com` suffixes | `"foo.com.com.com"` → `"foo.com"` |
+| Collapse double dots | `"foo..com"` → `"foo.com"` |
+| Must end with `.com` | `"foo.io"` → rejected |
+| Exactly two dot-separated parts | `"sub.foo.com"` → rejected |
+| Label matches `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` | `"foo-bar.com"` → valid; `"-foo.com"` → rejected |
+| Single-character labels allowed | `"a.com"` → valid |
+
+## Output
+
+Lists each removed domain with a `-` prefix:
+
+```
+- invalid-domain
+- another.bad.domain
+Cleaned domains.json
+```
+
+If nothing was removed:
+```
+No invalid domains found.
+```
+
+## Related Documentation
+
+- [AI Suggestions](ai-suggestions.md) — suggestions pass through the same `normalizeDomain` validation
+- [Configuration Reference](../guides/configuration.md)

--- a/docs/features/file-cleaning.md
+++ b/docs/features/file-cleaning.md
@@ -57,7 +57,23 @@ If nothing was removed:
 No invalid domains found.
 ```
 
+## Usage
+
+```bash
+# Clean a JSON domain file
+talia --clean domains.json
+
+# Clean a plain text domain file
+talia --clean domains.txt
+```
+
+## Limitations
+
+- No inline comment stripping for `.env`-style `# comment` at end of lines in plain text files — lines must start with `#` to be treated as comments.
+- Deduplication priority is fixed: available > unavailable > unverified. There is no way to customize this order.
+
 ## Related Documentation
 
+- [ADR-004: Output Format Design](../decisions/004-output-format-design.md) — defines the `ExtendedGroupedData` structure that `cleanSuggestionsFile` processes
 - [AI Suggestions](ai-suggestions.md) — suggestions pass through the same `normalizeDomain` validation
 - [Configuration Reference](../guides/configuration.md)

--- a/docs/features/file-cleaning.md
+++ b/docs/features/file-cleaning.md
@@ -43,11 +43,12 @@ The file content is tested with `json.Valid()`:
 
 ## Output
 
-Lists each removed domain with a `-` prefix:
+Prints a count header, then lists each removed domain with an indented `-` prefix:
 
 ```
-- invalid-domain
-- another.bad.domain
+Removed 2 invalid domains:
+  - invalid-domain
+  - another.bad.domain
 Cleaned domains.json
 ```
 

--- a/docs/features/merge-and-export.md
+++ b/docs/features/merge-and-export.md
@@ -30,7 +30,7 @@ There are two distinct merge implementations in the codebase:
 1. **`mergeFiles()`** (`--merge` flag) — flat `seen` map, first-write-wins, normalizes domains.
 2. **`mergeGrouped()`** (`--output-file` with `--grouped-output`) — two maps (available/unavailable), **newest-wins** with bucket switching. A domain moving from taken to available in a newer run will be reclassified. Does not normalize domains.
 
-These have intentionally different semantics for different use cases.
+These have intentionally different semantics for different use cases. Note that `mergeGrouped` operates on `GroupedData` (no `unverified` field), so `unverified` entries are silently dropped when merging via `--output-file`.
 
 ## Export Available (`--export-available`)
 

--- a/docs/features/merge-and-export.md
+++ b/docs/features/merge-and-export.md
@@ -1,0 +1,56 @@
+# Merge and Export
+
+File merging with deduplication and plain text export of available domains.
+
+## Merge (`--merge`)
+
+Combines two or more domain files into one with deduplication.
+
+### Usage
+
+```bash
+# Merge file2 into file1 (file1 is overwritten)
+talia --merge domains1.json domains2.json
+
+# Merge into a new output file
+talia --merge -o combined.json domains1.json domains2.json domains3.json
+```
+
+### Behavior
+
+- Requires at least 2 files, or 1 file with `-o` specified.
+- Uses a global `seen` map with **first-write-wins** semantics — once a domain appears in any section, subsequent occurrences in later files are ignored.
+- All domains pass through `normalizeDomain()` for validation.
+- Reads each file as `ExtendedGroupedData`, accumulates into a single structure.
+
+### Note on Merge Semantics
+
+There are two distinct merge implementations in the codebase:
+
+1. **`mergeFiles()`** (`--merge` flag) — flat `seen` map, first-write-wins, normalizes domains.
+2. **`mergeGrouped()`** (`--output-file` with `--grouped-output`) — two maps (available/unavailable), **newest-wins** with bucket switching. A domain moving from taken to available in a newer run will be reclassified. Does not normalize domains.
+
+These have intentionally different semantics for different use cases.
+
+## Export Available (`--export-available`)
+
+Writes all available domains from a file to a plain text file (one domain per line).
+
+### Usage
+
+```bash
+talia --export-available available.txt domains.json
+```
+
+### Behavior
+
+- Reads the input file as `ExtendedGroupedData`.
+- Extracts only `data.Available` entries.
+- Writes domain names one per line with a trailing newline.
+- Order is preserved from the input file.
+
+## Related Documentation
+
+- [ADR-004: Output Format Design](../decisions/004-output-format-design.md)
+- [Domain Checking](domain-checking.md)
+- [Configuration Reference](../guides/configuration.md)

--- a/docs/features/merge-and-export.md
+++ b/docs/features/merge-and-export.md
@@ -49,8 +49,15 @@ talia --export-available available.txt domains.json
 - Writes domain names one per line with a trailing newline.
 - Order is preserved from the input file.
 
+## Limitations
+
+- `mergeFiles` uses first-write-wins, so file order matters when domains appear in different sections across files.
+- `mergeGrouped` (used by `--output-file`) produces non-deterministic JSON ordering due to Go map iteration. See [Known Issues](../plans/known-issues.md).
+- `mergeGrouped` operates on `GroupedData` which has no `unverified` field — unverified entries are silently dropped during merge via `--output-file`.
+
 ## Related Documentation
 
 - [ADR-004: Output Format Design](../decisions/004-output-format-design.md)
 - [Domain Checking](domain-checking.md)
+- [File Cleaning](file-cleaning.md) — shares `normalizeDomain()` validation
 - [Configuration Reference](../guides/configuration.md)

--- a/docs/features/parallel-processing.md
+++ b/docs/features/parallel-processing.md
@@ -57,8 +57,15 @@ talia --whois whois.verisign-grs.com:43 --lightspeed max domains.json
 talia --suggest 10 --suggest-parallel 3 --prompt "short tech startup names" domains.json
 ```
 
+## Limitations
+
+- `"max"` mode with thousands of domains will open that many TCP connections simultaneously, which may trigger WHOIS server rate limiting or IP bans.
+- Invalid `--lightspeed` values (including `0` and negative numbers) silently default to 10 workers with no warning. See [Known Issues](../plans/known-issues.md).
+- Parallel AI requests receive identical exclusion lists, so they may return overlapping suggestions. Deduplication happens after all requests complete.
+
 ## Related Documentation
 
 - [ADR-003: Parallel Processing Design](../decisions/003-parallel-processing-design.md)
 - [Domain Checking](domain-checking.md)
 - [AI Suggestions](ai-suggestions.md)
+- [Configuration Reference](../guides/configuration.md)

--- a/docs/features/parallel-processing.md
+++ b/docs/features/parallel-processing.md
@@ -1,0 +1,64 @@
+# Parallel Processing
+
+Concurrent WHOIS checking and AI suggestion requests.
+
+## Parallel WHOIS (`--lightspeed`)
+
+### Modes
+
+| Value | Behavior |
+|---|---|
+| `"max"` | One goroutine per domain (capped to `len(domains)`) |
+| Integer (e.g., `"10"`) | Fixed worker pool of that size |
+| Invalid string | Defaults silently to 10 workers |
+| Not set | Sequential mode with `--sleep` delay |
+
+### Implementation
+
+- **Worker pool** uses a buffered channel pre-filled with all jobs.
+- **Order preservation:** results are written to a pre-indexed slice (`results[job.index]`), so output order matches input regardless of goroutine scheduling.
+- **Progress output:** mutex-protected `fmt.Printf` prevents interleaved lines.
+- **Statistics:** `atomic.AddInt64` for lock-free counter increments (available, taken, errors, elapsed time).
+- **No sleep** between checks in parallel mode.
+
+### Example
+
+```bash
+# 20 concurrent workers
+talia --whois whois.verisign-grs.com:43 --lightspeed 20 domains.json
+
+# Maximum parallelism (one goroutine per domain)
+talia --whois whois.verisign-grs.com:43 --lightspeed max domains.json
+```
+
+## Parallel AI Suggestions (`--suggest-parallel`)
+
+### Behavior
+
+- All N goroutines launch simultaneously (no worker pool).
+- Each fires an independent HTTP request to the AI API with identical parameters.
+- Results are accumulated under a `sync.Mutex` into a shared slice.
+- A `sync.WaitGroup` waits for all to complete.
+
+### Failure Handling
+
+- **All requests fail:** exits with code 1 and the first error message.
+- **Some fail, some succeed:** prints a warning to stderr, continues with partial results.
+
+### Deduplication
+
+- Parallel requests receive the same exclusion list (snapshot taken before goroutines start), so they may return overlapping suggestions.
+- `writeSuggestionsFile()` deduplicates against the full file contents after all requests complete.
+
+### Example
+
+```bash
+# 3 parallel requests, 10 suggestions each = up to 30 suggestions
+talia --suggest 10 --suggest-parallel 3 --prompt "short tech startup names" domains.json
+```
+
+## Related Documentation
+
+- [ADR-003: Parallel Processing Design](../decisions/003-parallel-processing-design.md)
+- [Domain Checking](domain-checking.md)
+- [AI Suggestions](ai-suggestions.md)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -46,15 +46,36 @@ explicit CLI flag  >  shell environment variable  >  .env file
 
 ### `.env` File
 
-Talia loads a `.env` file from the current working directory at startup. Rules:
+Talia loads a `.env` file from the current working directory at startup.
+
+Example `.env` file:
+
+```
+OPENAI_API_KEY=your-api-key
+OPENAI_API_BASE=https://generativelanguage.googleapis.com/v1beta/openai
+WHOIS_SERVER=whois.verisign-grs.com:43
+TALIA_PROMPT=short brandable startup names
+TALIA_SUGGEST=10
+TALIA_MODEL=gemini-2.5-flash
+TALIA_FILE=suggestions.json
+```
+
+Rules:
 
 - Does **not** override existing shell environment variables.
 - Supports `KEY=VALUE` format (matching quotes — both `"` or both `'` — are stripped from values).
+- Lines without `=` are silently skipped.
+- No inline comment stripping — `KEY=value # comment` sets the value to `value # comment` (the full right-hand side).
+- A variable set to empty string in the shell (`export KEY=""`) counts as "existing" and will not be overwritten.
 - Silently ignored if the file doesn't exist.
 
-### `--model` / `TALIA_MODEL` Edge Case
+### Env Var Override Quirks
 
-The env var `TALIA_MODEL` only takes effect when the `--model` flag is at its hardcoded default (`gpt-5-mini`). This means explicitly passing `--model=gpt-5-mini` on the CLI still allows the env var to override it, since the comparison is against the string constant rather than whether the flag was explicitly set.
+The env vars for `--model` and `--suggest-parallel` only apply when the flag value equals its hardcoded default. This means explicitly passing the default value on the CLI (e.g., `--model=gpt-5-mini` or `--suggest-parallel=1`) still allows the env var to override it, since the comparison is against the string constant rather than whether the flag was explicitly set. See [Known Issues](../plans/known-issues.md).
+
+### `--sleep` During Auto-Verification
+
+The `--sleep` flag is ignored during the auto-verification step after `--suggest`. Auto-verification uses a hardcoded 100ms delay between WHOIS checks for speed. The `--sleep` value only applies to standalone WHOIS checking runs.
 
 ## Related Documentation
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,0 +1,63 @@
+# Configuration Reference
+
+All CLI flags, environment variables, and `.env` file support.
+
+## CLI Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--whois` | string | — | WHOIS server in `host:port` format. Required for domain checking |
+| `--sleep` | duration | `2s` | Delay between sequential WHOIS checks. Ignored in parallel mode |
+| `--verbose` | bool | `false` | Include raw WHOIS response in `log` field for all results |
+| `--grouped-output` | bool | `false` | Output as `{available:[], unavailable:[]}` instead of array |
+| `--output-file` | string | — | Separate file for grouped output (leaves input unchanged) |
+| `--suggest` | int | `0` | Number of AI suggestions to generate per request |
+| `--suggest-parallel` | int | `1` | Number of concurrent AI suggestion requests |
+| `--prompt` | string | — | Natural language prompt to guide AI suggestions |
+| `--model` | string | `gpt-5-mini` | AI model name |
+| `--api-base` | string | — | Base URL for OpenAI-compatible API |
+| `--fresh` | bool | `false` | Don't send existing domains as exclusions to AI |
+| `--clean` | bool | `false` | Normalize/deduplicate domains in the file, then exit |
+| `--no-verify` | bool | `false` | Skip WHOIS verification after generating suggestions |
+| `--merge` | bool | `false` | Merge multiple domain files with deduplication |
+| `-o` | string | — | Output file for `--merge` |
+| `--export-available` | string | — | Export available domains to a plain text file |
+| `--lightspeed` | string | — | Parallel WHOIS: `"max"`, an integer, or empty for sequential |
+
+## Environment Variables
+
+| Variable | Fallback for | Notes |
+|---|---|---|
+| `TALIA_FILE` | positional arg | Target file path |
+| `WHOIS_SERVER` | `--whois` | WHOIS server `host:port` |
+| `OPENAI_API_KEY` | — | Required for `--suggest`. No flag equivalent |
+| `OPENAI_API_BASE` | `--api-base` | Falls back to `https://api.openai.com/v1` |
+| `TALIA_SUGGEST` | `--suggest` | Ignored if file has pending `unverified` domains |
+| `TALIA_SUGGEST_PARALLEL` | `--suggest-parallel` | Number of parallel AI requests |
+| `TALIA_PROMPT` | `--prompt` | Extra context for AI suggestions |
+| `TALIA_MODEL` | `--model` | Only applies when `--model` is at its default value |
+| `TALIA_LIGHTSPEED` | `--lightspeed` | Parallel WHOIS worker count |
+
+## Precedence
+
+```
+explicit CLI flag  >  shell environment variable  >  .env file
+```
+
+### `.env` File
+
+Talia loads a `.env` file from the current working directory at startup. Rules:
+
+- Does **not** override existing shell environment variables.
+- Supports `KEY=VALUE` format (quotes are stripped).
+- Silently ignored if the file doesn't exist.
+
+### `--model` / `TALIA_MODEL` Edge Case
+
+The env var `TALIA_MODEL` only takes effect when the `--model` flag is at its hardcoded default (`gpt-5-mini`). This means explicitly passing `--model=gpt-5-mini` on the CLI still allows the env var to override it, since the comparison is against the string constant rather than whether the flag was explicitly set.
+
+## Related Documentation
+
+- [Development Guide](development.md)
+- [Domain Checking](../features/domain-checking.md)
+- [AI Suggestions](../features/ai-suggestions.md)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -49,7 +49,7 @@ explicit CLI flag  >  shell environment variable  >  .env file
 Talia loads a `.env` file from the current working directory at startup. Rules:
 
 - Does **not** override existing shell environment variables.
-- Supports `KEY=VALUE` format (quotes are stripped).
+- Supports `KEY=VALUE` format (matching quotes — both `"` or both `'` — are stripped from values).
 - Silently ignored if the file doesn't exist.
 
 ### `--model` / `TALIA_MODEL` Edge Case

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -1,0 +1,85 @@
+# Development Guide
+
+Building, running, and contributing to Talia.
+
+## Prerequisites
+
+- Go 1.24.3+ (uses `tool` directive in `go.mod` for golangci-lint)
+
+## Build
+
+```bash
+go build -o talia
+```
+
+The binary is built from `cmd/talia/main.go`, which is a thin wrapper around `talia.RunCLI()`.
+
+## Run
+
+```bash
+# Basic WHOIS check
+./talia --whois whois.verisign-grs.com:43 domains.json
+
+# Generate AI suggestions
+export OPENAI_API_KEY=sk-...
+./talia --suggest 10 --prompt "short tech names" domains.json
+
+# Clean a domain file
+./talia --clean domains.json
+```
+
+## Project Structure
+
+```
+cmd/talia/main.go     # binary entry point
+cli.go                # flag parsing and orchestration
+whois.go              # TCP WHOIS client
+types.go              # all data structures
+grouped.go            # merge/deduplicate logic for grouped format
+suggestions.go        # OpenAI API, normalization, file utilities
+progress.go           # thread-safe progress output
+env.go                # .env file loader
+```
+
+All domain logic lives in the root `talia` package. The `cmd/talia/` sub-package exists only to produce the binary.
+
+## Lint
+
+```bash
+go tool golangci-lint run
+```
+
+Uses golangci-lint v2 via Go's tool directive — auto-downloads on first run. Config in `.golangci.yml` enables: `govet`, `staticcheck`, `errcheck`.
+
+## Commit Convention
+
+Enforced by commitlint in CI. Allowed types:
+
+`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `style`, `revert`
+
+Example: `feat: add new flag for TLD filtering`
+
+See `.commitlintrc.json` for the full config.
+
+## CI Pipeline
+
+Defined in `.github/workflows/ci.yml`. Runs on every push and PR:
+
+1. Commit message lint (commitlint)
+2. `go vet ./...`
+3. `go test -race -coverprofile=coverage.out ./...`
+4. golangci-lint
+5. Coverage artifact upload
+
+## Release Process
+
+Defined in `.github/workflows/release.yml`. Runs on pushes to `main`:
+
+- Uses `release-please-action` v4 with `release-type: simple`
+- Auto-generates changelog from conventional commits
+- Creates release PRs and tags with `v` prefix
+
+## Related Documentation
+
+- [Testing Guide](testing.md)
+- [Configuration Reference](configuration.md)

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -4,7 +4,7 @@ Building, running, and contributing to Talia.
 
 ## Prerequisites
 
-- Go 1.24.3+ (uses `tool` directive in `go.mod` for golangci-lint)
+- Go 1.24.3 (as specified in `go.mod`; uses `tool` directive for golangci-lint)
 
 ## Build
 
@@ -49,7 +49,9 @@ All domain logic lives in the root `talia` package. The `cmd/talia/` sub-package
 go tool golangci-lint run
 ```
 
-Uses golangci-lint v2 via Go's tool directive — auto-downloads on first run. Config in `.golangci.yml` enables: `govet`, `staticcheck`, `errcheck`.
+Uses golangci-lint v2 (pinned to v2.8.0 in `go.mod`) via Go's tool directive — auto-downloads on first run. Config in `.golangci.yml` explicitly enables: `govet`, `staticcheck`, `errcheck`.
+
+Note: CI uses `golangci/golangci-lint-action@v8` (GitHub Action) rather than `go tool golangci-lint run`, but both read the same `.golangci.yml` config.
 
 ## Commit Convention
 

--- a/docs/guides/documentation-system-playbook.md
+++ b/docs/guides/documentation-system-playbook.md
@@ -227,3 +227,7 @@ This structure is intentionally domain-agnostic. You can rename folders if neede
 - templates
 
 If you preserve that separation, the system scales across mobile, backend, infra, and full-stack projects.
+
+## Related Documentation
+
+- [Documentation Index](../README.md)

--- a/docs/guides/documentation-system-playbook.md
+++ b/docs/guides/documentation-system-playbook.md
@@ -1,0 +1,229 @@
+# Universal Documentation System Playbook
+
+A reusable documentation architecture you can apply to most software projects.
+
+## Purpose
+
+This playbook defines a documentation system that is:
+- easy to navigate
+- hard to duplicate
+- clear about ownership
+- scalable as product and team complexity grows
+
+It separates documentation by intent ("why", "how", "workflow", "history", "external copy") so readers can find the right source of truth fast.
+
+## Core Design Principles
+
+1. Single source of truth per concern.
+2. Separate rationale from behavior from implementation workflow.
+3. Keep indexes opinionated and concise.
+4. Prefer cross-links over repeated content.
+5. Evolve with templates and explicit maintenance rules.
+
+## Recommended Directory Structure
+
+```text
+docs/
+  README.md                 # master index and taxonomy
+  decisions/                # architecture and technical rationale
+  features/                 # product behavior and platform rules
+  guides/                   # standards and implementation playbooks
+  plans/                    # audits, migration plans, open risks
+  marketing/                # external copy and review responses
+  prompts/                  # prompt assets/specs (if AI is used)
+  templates/                # authoring templates for all doc types
+```
+
+## Folder Contracts
+
+### `docs/README.md`
+
+Must include:
+- structure map (tree)
+- doc-type taxonomy
+- links to each section index or key docs
+- authoring and maintenance rules
+
+Purpose:
+- onboarding entrypoint for all contributors
+
+### `docs/decisions/`
+
+Use for:
+- architectural choices
+- alternatives considered
+- tradeoffs and consequences
+
+Do not use for:
+- step-by-step implementation tasks
+- user-facing behavior details
+
+### `docs/features/`
+
+Use for:
+- expected product behavior
+- platform differences
+- edge cases and state handling
+
+Do not use for:
+- architecture debates (link to decisions instead)
+- contributor workflows (link to guides instead)
+
+### `docs/guides/`
+
+Use for:
+- durable standards (design, content, quality bars)
+- implementation playbooks
+- contributor runbooks
+
+Typical examples:
+- design philosophy
+- widget/module development guide
+- integration or release checklist guide
+
+### `docs/plans/`
+
+Use for:
+- audit snapshots
+- migration plans
+- unresolved items and risk tracking
+
+Rule:
+- explicitly date and status plan documents
+
+### `docs/marketing/`
+
+Use for:
+- app store copy
+- launch messaging
+- reviewer responses
+
+Rule:
+- isolate from engineering specs to avoid cross-purpose edits
+
+### `docs/prompts/` (optional)
+
+Use for:
+- prompt contracts
+- reusable prompt assets
+
+Rule:
+- keep outputs deterministic in shape (sections, fields, constraints)
+
+### `docs/templates/`
+
+Use for:
+- canonical authoring skeletons
+
+Rule:
+- update templates whenever recurring section standards change
+
+## Doc Type Decision Matrix
+
+Use this to decide where new content belongs:
+
+- "Why did we choose this architecture?" -> `decisions/`
+- "How should the feature behave?" -> `features/`
+- "How do I implement or operate this?" -> `guides/`
+- "What is pending/risky/open?" -> `plans/`
+- "What do users/reviewers read externally?" -> `marketing/`
+- "How should prompts be written?" -> `prompts/`
+
+## Standard Template Set
+
+At minimum, maintain templates for:
+- docs index/readme
+- decision record
+- feature spec
+- plan/audit
+- marketing doc
+- philosophy/standards doc
+- implementation guide
+- prompt doc (if applicable)
+
+## Authoring Rules (Universal)
+
+1. One primary topic per file.
+2. Stable heading hierarchy (`#`, then `##` for key sections).
+3. Use relative links for local navigation.
+4. Add `Related Documentation` section near the end.
+5. Use explicit dates (`YYYY-MM-DD`) when time matters.
+6. Prefer bullet constraints over long prose when defining rules.
+7. Keep examples concrete (paths, commands, model names, flows).
+
+## Link and Consistency Rules
+
+1. Every major doc is reachable from `docs/README.md` within 2 clicks.
+2. Every feature doc links to at least one related decision or guide.
+3. Every decision links to affected feature docs.
+4. Every guide links to relevant feature/decision docs.
+5. Run markdown link validation after structural changes.
+
+## Governance Model
+
+Define owners explicitly:
+- `decisions/`: architecture owner or tech lead
+- `features/`: product + engineering owner for that domain
+- `guides/`: domain maintainer
+- `plans/`: project lead or incident owner
+- `marketing/`: product/marketing owner
+- `templates/`: docs maintainer
+
+Add a simple review cadence:
+- monthly docs health check
+- pre-release docs audit
+- post-incident docs update checklist
+
+## Lifecycle Rules
+
+When code changes:
+1. Update affected feature/guide/decision docs in the same PR.
+2. If architecture changed, update `decisions/` first, then link from feature docs.
+3. If behavior changed, update `features/` and related guides.
+4. If language or positioning changed, update philosophy/marketing docs.
+
+When structure changes:
+1. update `docs/README.md`
+2. update section indexes (for example `docs/guides/README.md`)
+3. update templates
+4. run link validation
+
+## Migration Playbook (Adopting This in Another Project)
+
+1. Create the baseline folder tree under `docs/`.
+2. Add `docs/README.md` with taxonomy and section links.
+3. Install template files in `docs/templates/`.
+4. Migrate existing docs into `decisions`, `features`, `guides`, `plans`, `marketing`.
+5. Replace duplicate content with cross-links.
+6. Add section indexes for high-volume folders (for example `guides/README.md`).
+7. Add CI or local checks for markdown link validity.
+8. Add contribution rule: docs updated in same change as code.
+
+## Anti-Patterns to Avoid
+
+- giant mixed docs containing rationale + behavior + implementation + status
+- orphan docs that are not linked from the main index
+- duplicate guidance across multiple folders
+- template drift where real docs no longer match skeletons
+- architecture facts living only in PR descriptions
+
+## Acceptance Checklist
+
+- [ ] `docs/README.md` exists and reflects actual structure
+- [ ] each folder has a clear contract
+- [ ] templates exist for each active doc type
+- [ ] section indexes exist where needed (`guides/README.md`, etc.)
+- [ ] no broken relative markdown links
+- [ ] at least one owner is accountable for docs quality
+
+## Adaptation Notes
+
+This structure is intentionally domain-agnostic. You can rename folders if needed, but keep the functional separation:
+- rationale
+- behavior
+- implementation workflow
+- planning/risk
+- external messaging
+- templates
+
+If you preserve that separation, the system scales across mobile, backend, infra, and full-stack projects.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,71 @@
+# Testing Guide
+
+Test architecture, mocking strategy, and CI integration.
+
+## Running Tests
+
+```bash
+# Standard
+go test -v
+
+# With race detection and coverage
+go test -race -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out
+```
+
+## Test Files
+
+| File | Scope |
+|---|---|
+| `main_test.go` | Integration tests for all CLI paths (~2440 lines) |
+| `whois_test.go` | Unit tests for WHOIS client via `fakeWhoisClient` |
+| `suggestions_test.go` | Unit and integration tests for AI suggestion pipeline |
+| `cmd/talia/main_test.go` | Tests that `main()` exits non-zero with no args |
+
+All library tests are in the `talia` package (white-box), giving access to unexported types and functions.
+
+## Mocking Strategy
+
+### WHOIS Mocking
+
+Two approaches:
+
+1. **`WhoisClient` interface** — `fakeWhoisClient` returns hardcoded responses for pure unit tests of availability logic.
+2. **In-process TCP listeners** — `net.Listen("tcp", "127.0.0.1:0")` with goroutines serving predictable responses for integration tests that exercise the full TCP path.
+
+### HTTP Mocking (AI API)
+
+- `httptest.NewServer` provides a local HTTP server with controlled responses.
+- The `httpDoer` interface and package-level `testHTTPClient`/`testBaseURL` vars are the injection points.
+- Integration tests (`TestRunCLISuggest`, etc.) set these vars directly to route requests through the test server.
+
+## Test Isolation
+
+`TestMain` (in `main_test.go`) runs before all tests and:
+
+- Sets `skipEnvFile = true` to prevent `.env` file loading during tests.
+- Unsets `OPENAI_API_KEY` and `OPENAI_API_BASE` to prevent real API calls.
+
+Individual tests that modify env vars use `defer os.Unsetenv(...)` for cleanup.
+
+## Output Capture
+
+The `captureOutput` helper (in `main_test.go`) uses `os.Pipe()` to redirect `os.Stdout` and `os.Stderr`, allowing test assertions on terminal output without consuming the actual terminal.
+
+## Parallelism in Tests
+
+- Pure unit tests are marked `t.Parallel()`.
+- Integration tests that touch shared package-level vars (`testHTTPClient`, `testBaseURL`) are **not** parallel.
+- CI runs `go test -race ./...` — the parallel WHOIS checker is designed to be race-detector clean (atomic counters, result-by-index writes, mutex for printing).
+
+## Key Patterns
+
+- **Flag isolation:** `RunCLI` uses `flag.NewFlagSet` (not `flag.CommandLine`), so parallel tests don't share flag state.
+- **Temp files:** Tests create temporary files for input/output and clean up via `defer os.Remove(...)`.
+- **Exit code testing:** `cmd/talia/main_test.go` overrides the `exitFunc` variable to capture exit codes without actually calling `os.Exit`.
+
+## Related Documentation
+
+- [Development Guide](development.md)
+- [Domain Checking](../features/domain-checking.md)
+- [AI Suggestions](../features/ai-suggestions.md)

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -17,7 +17,7 @@ go tool cover -func=coverage.out
 
 | File | Scope |
 |---|---|
-| `main_test.go` | Integration tests for all CLI paths (~2440 lines) |
+| `main_test.go` | Integration tests for all CLI paths |
 | `whois_test.go` | Unit tests for WHOIS client via `fakeWhoisClient` |
 | `suggestions_test.go` | Unit and integration tests for AI suggestion pipeline |
 | `cmd/talia/main_test.go` | Tests that `main()` exits non-zero with no args |

--- a/docs/plans/known-issues.md
+++ b/docs/plans/known-issues.md
@@ -24,7 +24,7 @@ Two `.env` loading implementations exist:
 - `cmd/talia/main.go` (lines 12-26): inline loader that **always overwrites** existing env vars.
 - `env.go` / `LoadEnvFile()`: more complete loader with quote stripping that **does not override** existing vars.
 
-Both run at startup. The `main.go` loader runs first, so its overwrite behavior takes precedence for any vars set in `.env`.
+Both run at startup. The `main.go` loader runs first, so its overwrite behavior takes precedence for any vars set in `.env`. Additionally, the `main.go` loader does not strip quotes from values (uses raw `strings.Cut` + `strings.TrimSpace`), while `LoadEnvFile` does strip matching quotes.
 
 ---
 
@@ -54,6 +54,15 @@ Invalid `--lightspeed` values (non-integer, non-`"max"` strings) silently defaul
 The `"No match for"` availability check only works with Verisign-style WHOIS servers (`.com`, `.net`). Other registries use different response formats and will silently report all domains as taken.
 
 **Mitigation:** Documented in README and [ADR-001](../decisions/001-whois-availability-detection.md). The `WhoisClient` interface allows swapping in a more sophisticated implementation.
+
+---
+
+### ANSI color codes with no TTY detection
+
+**Severity:** Low
+**Component:** `progress.go`
+
+Progress output uses ANSI escape codes unconditionally. If stdout is piped or redirected to a file, raw escape codes will appear in the output. There is no `isatty` check to disable colors.
 
 ## Related Documentation
 

--- a/docs/plans/known-issues.md
+++ b/docs/plans/known-issues.md
@@ -33,7 +33,7 @@ Both run at startup. The `main.go` loader runs first, so its overwrite behavior 
 **Severity:** Low
 **Component:** `cli.go`
 
-Invalid `--lightspeed` values (non-integer, non-`"max"` strings) silently default to 10 workers with no warning. Users may not realize their input was ignored.
+Invalid `--lightspeed` values (non-integer, non-`"max"` strings), zero, and negative numbers all silently default to 10 workers with no warning. Users may not realize their input was ignored.
 
 ---
 
@@ -64,8 +64,28 @@ The `"No match for"` availability check only works with Verisign-style WHOIS ser
 
 Progress output uses ANSI escape codes unconditionally. If stdout is piped or redirected to a file, raw escape codes will appear in the output. There is no `isatty` check to disable colors.
 
+---
+
+### `--suggest-parallel` env var override quirk
+
+**Severity:** Low
+**Component:** `cli.go`
+
+`TALIA_SUGGEST_PARALLEL` overrides `--suggest-parallel` when the flag value equals the default (`1`), even if the user explicitly passed `--suggest-parallel=1`. Same pattern as the `--model` / `TALIA_MODEL` quirk.
+
+---
+
+### `--sleep` ignored during auto-verification
+
+**Severity:** Low
+**Component:** `cli.go`
+
+When `--suggest` triggers auto-verification, the WHOIS sleep is hardcoded to 100ms regardless of the user's `--sleep` value. This is by design for speed, but the `--sleep` flag docs don't mention this exception.
+
 ## Related Documentation
 
 - [ADR-001: WHOIS Availability Detection](../decisions/001-whois-availability-detection.md)
 - [ADR-004: Output Format Design](../decisions/004-output-format-design.md)
+- [Parallel Processing](../features/parallel-processing.md)
+- [Merge and Export](../features/merge-and-export.md)
 - [Configuration Reference](../guides/configuration.md)

--- a/docs/plans/known-issues.md
+++ b/docs/plans/known-issues.md
@@ -1,0 +1,62 @@
+# Known Issues
+
+**Last updated:** 2026-03-10
+
+## Open Issues
+
+### Non-deterministic merge output ordering
+
+**Severity:** Low
+**Component:** `grouped.go` — `mergeGrouped()`
+
+`mergeGrouped()` uses Go map iteration to build the output arrays, producing non-deterministic JSON ordering on each run. This causes noisy diffs if the output file is version-controlled.
+
+**Workaround:** Sort the output externally with `jq` if stable ordering is needed.
+
+---
+
+### Duplicate `.env` loaders
+
+**Severity:** Low
+**Component:** `cmd/talia/main.go` vs `env.go`
+
+Two `.env` loading implementations exist:
+- `cmd/talia/main.go` (lines 12-26): inline loader that **always overwrites** existing env vars.
+- `env.go` / `LoadEnvFile()`: more complete loader with quote stripping that **does not override** existing vars.
+
+Both run at startup. The `main.go` loader runs first, so its overwrite behavior takes precedence for any vars set in `.env`.
+
+---
+
+### `--lightspeed` silent default
+
+**Severity:** Low
+**Component:** `cli.go`
+
+Invalid `--lightspeed` values (non-integer, non-`"max"` strings) silently default to 10 workers with no warning. Users may not realize their input was ignored.
+
+---
+
+### `--model` env var override quirk
+
+**Severity:** Low
+**Component:** `cli.go`
+
+`TALIA_MODEL` overrides `--model` when the flag value equals the hardcoded default (`gpt-5-mini`), even if the user explicitly passed `--model=gpt-5-mini`. The comparison checks the string value, not whether the flag was explicitly set.
+
+---
+
+### WHOIS detection limited to Verisign servers
+
+**Severity:** Medium
+**Component:** `whois.go`
+
+The `"No match for"` availability check only works with Verisign-style WHOIS servers (`.com`, `.net`). Other registries use different response formats and will silently report all domains as taken.
+
+**Mitigation:** Documented in README and [ADR-001](../decisions/001-whois-availability-detection.md). The `WhoisClient` interface allows swapping in a more sophisticated implementation.
+
+## Related Documentation
+
+- [ADR-001: WHOIS Availability Detection](../decisions/001-whois-availability-detection.md)
+- [ADR-004: Output Format Design](../decisions/004-output-format-design.md)
+- [Configuration Reference](../guides/configuration.md)

--- a/docs/templates/decision-record.md
+++ b/docs/templates/decision-record.md
@@ -1,0 +1,27 @@
+# ADR-NNN: Title
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-NNN
+
+## Context
+
+What is the issue or requirement that motivated this decision?
+
+## Decision
+
+What is the change being proposed or adopted? Include key design choices and implementation details.
+
+## Alternatives Considered
+
+1. **Alternative A** — brief description and why it was rejected.
+2. **Alternative B** — brief description and why it was rejected.
+
+## Consequences
+
+- **Pro:** positive outcome
+- **Con:** negative outcome or tradeoff
+
+## Related Documentation
+
+- [Link to affected feature spec](../features/)
+- [Link to related guide](../guides/)

--- a/docs/templates/feature-spec.md
+++ b/docs/templates/feature-spec.md
@@ -1,0 +1,34 @@
+# Feature Name
+
+Brief one-line description.
+
+## Overview
+
+What does this feature do and why does it exist?
+
+## How It Works
+
+Step-by-step description of the feature's behavior.
+
+## Usage
+
+```bash
+# Example command
+talia --flag value file.json
+```
+
+## Edge Cases
+
+- Edge case 1
+- Edge case 2
+
+## Limitations
+
+- Known limitation 1
+- Known limitation 2
+
+## Related Documentation
+
+- [Link to decision record](../decisions/)
+- [Link to related feature](../features/)
+- [Link to configuration](../guides/configuration.md)

--- a/docs/templates/guide.md
+++ b/docs/templates/guide.md
@@ -1,0 +1,33 @@
+# Guide Title
+
+Brief description of what this guide covers.
+
+## Prerequisites
+
+- Prerequisite 1
+- Prerequisite 2
+
+## Steps
+
+### Step 1: Title
+
+Description and commands.
+
+```bash
+# example command
+```
+
+### Step 2: Title
+
+Description and commands.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| Issue description | How to fix it |
+
+## Related Documentation
+
+- [Link to feature spec](../features/)
+- [Link to decision record](../decisions/)

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -1,0 +1,33 @@
+# Plan Title
+
+**Last updated:** YYYY-MM-DD
+**Status:** Draft | Active | Completed | Abandoned
+
+## Summary
+
+What is this plan about?
+
+## Open Items
+
+### Item Title
+
+**Severity:** Low | Medium | High | Critical
+**Component:** affected file or module
+
+Description of the issue, risk, or pending work.
+
+**Workaround:** (if applicable)
+
+---
+
+### Item Title
+
+**Severity:** Low | Medium | High | Critical
+**Component:** affected file or module
+
+Description.
+
+## Related Documentation
+
+- [Link to decision record](../decisions/)
+- [Link to feature spec](../features/)


### PR DESCRIPTION
## Summary

- Implement full `docs/` directory structure following the documentation system playbook: decisions, features, guides, plans, and templates
- 4 architecture decision records, 5 feature specs, 3 development guides, known issues tracker, and 4 authoring templates (19 files, ~1100 lines)
- Streamline CLAUDE.md to executive summary + docs TOC
- Fix README prerequisites: Go 1.24.3 (was 1.16), golangci-lint v2.8.0 (was v2.1.6)
- Add Documentation section to README linking to docs/

## Test plan

- [ ] Verify all relative markdown links resolve correctly
- [ ] Confirm docs content matches current codebase behavior
- [ ] Check CLAUDE.md TOC links work from repo root